### PR TITLE
correction documentation - theme name in config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Installation
 
-The easiest way is to clone this repo (or add as a submodule) to themes/nostyleplease then append `theme = 'nostyleplease'` as a newline to config.toml. Pages shipped with theme as examples have `draft: true` in their frontmatters, use `--buildDrafts` to build them.
+The easiest way is to clone this repo (or add as a submodule) to themes/nostyleplease then append `theme = 'hugo-theme-nostyleplease'` as a newline to config.toml. Pages shipped with theme as examples have `draft: true` in their frontmatters, use `--buildDrafts` to build them.
 
 ## Usage
 


### PR DESCRIPTION
In the documentation, to set the theme It was written :
`theme = 'nostyleplease'`

But the repo's name is actually `hugo-theme-nostyleplease ` so the _correct_ way to set the theme in config.toml is :
`theme = 'hugo-theme-nostyleplease'`