### PR TITLE
Fix Hugo WARN deprecated

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,7 +16,7 @@
   <link rel="shortcut icon" type="image/x-icon" href="{{ $.Site.Params.favicon | relURL }}" />
   {{ $options := (dict "outputStyle" "compressed" "enableSourceMap" (not hugo.IsProduction)) }}
   {{ $sass := resources.Get "css/main.scss" }}
-  {{ $style := $sass | resources.ToCSS $options | resources.Fingerprint "sha512" }}
+  {{ $style := $sass | css.Sass $options | resources.Fingerprint "sha512" }}
   <link rel="stylesheet" href="{{ $style.Permalink | relURL }}" integrity="{{ $style.Data.Integrity }}" />
   {{ if .Params.mathjax }} {{ partial "mathjax.html" . }} {{ end }}
 </head>


### PR DESCRIPTION
I'm running `hugo server` today and this is my first time to generate hugo blog with this theme. But I saw a warn about this:
```
Watching for changes in /home/freeez/Documents/blog/{archetypes,assets,content,data,i18n,layouts,static,themes}
Watching for config changes in /home/freeez/Documents/blog/hugo.toml, /home/freeez/Documents/blog/themes/hugo-theme-nostyleplease/config.toml
Start building sites … 
hugo v0.134.3+extended linux/amd64 BuildDate=unknown

WARN  deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed in a future release. Use css.Sass instead.

                   | EN  
-------------------+-----
  Pages            | 10  
  Paginator pages  |  0  
  Non-page files   |  0  
  Static files     |  0  
  Processed images |  0  
  Aliases          |  0  
  Cleaned          |  0  

Built in 7 ms
Environment: "development"
Serving pages from disk
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at http://localhost:1313/ (bind address 127.0.0.1) 
Press Ctrl+C to stop
```
I have simply tested my change of the theme, and everything works well. Do we should take this change? Thank to every one make the theme better.