### PR TITLE
feat(config): Support toggle option for footer display

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 [module]
   [module.hugoVersion]
-    extended=true
-    min = "0.41.0"
+    extended = true
+    min      = "0.41.0"
 
 [markup]
   [markup.goldmark]
@@ -9,29 +9,31 @@
       [markup.goldmark.parser.attribute]
         block = true
         title = true
+
   [markup.highlight]
-    anchorLineNos = false
-    codeFences = true
-    guessSyntax = false
-    hl_Lines = ''
-    hl_inline = false
-    lineAnchors = ''
-    lineNoStart = 1
-    lineNos = false
+    anchorLineNos      = false
+    codeFences         = true
+    guessSyntax        = false
+    hl_Lines           = ''
+    hl_inline          = false
+    lineAnchors        = ''
+    lineNoStart        = 1
+    lineNos            = false
     lineNumbersInTable = true
-    noClasses = true
-    noHl = false
-    style = 'rrt'
-    tabWidth = 4
+    noClasses          = true
+    noHl               = false
+    style              = 'rrt'
+    tabWidth           = 4
+
   [markup.tableOfContents]
     startLevel = 2
-    endLevel = 3
-    ordered = false
+    endLevel   = 3
+    ordered    = false
 
 [params]
   [params.theme_config]
-    appearance = "auto"
-    back_home_text = ".."
-    date_format = "2006-01-02"
+    appearance        = "auto"
+    back_home_text    = ".."
+    date_format       = "2006-01-02"
     isListGroupByDate = false
-    isShowFooter = true
+    isShowFooter      = true

--- a/config.toml
+++ b/config.toml
@@ -34,3 +34,4 @@
     back_home_text = ".."
     date_format = "2006-01-02"
     isListGroupByDate = false
+    isShowFooter = true

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,2 +1,4 @@
-{{ $footerContent := readFile "layouts/footer.md" }}
-{{ $footerContent | markdownify }}
+{{ if site.Params.theme_config.isShowFooter }}
+    {{ $footerContent := readFile "layouts/footer.md" }}
+    {{ $footerContent | markdownify }}
+{{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,10 @@
 {{ if site.Params.theme_config.isShowFooter }}
-    {{ $footerContent := readFile "layouts/footer.md" }}
-    {{ $footerContent | markdownify }}
+    {{ with resources.Get "layouts/footer.md" }}
+        {{ .Content | markdownify }}
+    {{ else }}
+        {{ warnf "layouts/footer.md file is not found, fallback to the default copyright" }}
+        <footer class="site-footer">
+            <p>&copy; {{ now.Format "2006" }} {{ site.Title }}</p>
+        </footer>
+    {{ end }}
 {{ end }}


### PR DESCRIPTION
# Add toggle option for footer display

## Description

Adds configuration option to show/hide footer section globally.

## Changes

- Add `isShowFooter` boolean flag in theme configuration
- Implement conditional rendering in footer partial template
- Print warning message for fallback to default footer

```bash
WARN  layouts/footer.md file is not found, fallback to the default copyright
```

## Testing done

- [x] Verified footer displays when `isShowFooter = true` in `config.toml` file
- [x] Verified footer hides when `isShowFooter = false` in `config.toml` file