### PR TITLE
fix(css): Font size inconsistency in code snippets on iOS

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -118,6 +118,13 @@ table, th, td {
   padding: 0.4rem;
 }
 
+code {
+  text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+
 code:not(pre > code) {
   padding: 0.1em 0.2em;
   font-size: 90%;


### PR DESCRIPTION
## TL;DR

Fix font size inconsistencies in code snippets on iOS devices by adding specific CSS rules.

## Description

- Added CSS rules to ensure consistent font size for code elements across iOS devices. This change addresses the font size imbalance issue reported in code snippets.

> [!NOTE]
> This font problem occurs on mobile devices (currently confirmed on iOS + Safari), but does not affect PC.

- This bug can be traced back to this iOS issue with flex and font sizing: https://stackoverflow.com/questions/38346494/why-is-flex-affecting-font-size-on-ios

- **Related issue**: https://github.com/adityatelange/hugo-PaperMod/issues/828

## Screenshot

The screenshot below shows the issue with font size inconsistency in code snippets before applying the changes.

| Device | iOS Version | Screenshot  |
|--------|-------------|-------------|
| Safari  | 18.0.1     | ![Screenshot](https://github.com/user-attachments/assets/164f576a-1797-4a76-964f-75f8f5005891) |
