### PR TITLE
fix(partials): Footer rendering bug (#33)

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,8 +1,9 @@
 {{ if site.Params.theme_config.isShowFooter }}
-    {{ with resources.Get "layouts/footer.md" }}
-        {{ .Content | markdownify }}
+    {{ $footerContent := readFile "layouts/footer.md" }}
+    {{ if and $footerContent (ne $footerContent "") }}
+        {{ $footerContent | markdownify }}
     {{ else }}
-        {{ warnf "layouts/footer.md file is not found, fallback to the default copyright" }}
+        {{ warnf "layouts/footer.md file is not found or empty. Falling back to default footer." }}
         <footer class="site-footer">
             <p>&copy; {{ now.Format "2006" }} {{ site.Title }}</p>
         </footer>


### PR DESCRIPTION
Fix rendering bug causing fallback even when footer.md exists (reported in issue #33) @hanwenguo 

* conditional rendering: render footer if `layouts/footer.md` exists and has content; fallback if empty or missing

* Resolved #33, Caused by a0684e5add17d66d951b691c747981f1c32f91da